### PR TITLE
changed unixsocket to reflect hostname  in start script

### DIFF
--- a/redis-start.sh
+++ b/redis-start.sh
@@ -5,7 +5,8 @@ BIND_ADDRESS="127.0.0.1"
 APPENDONLY="no"
 SAVE=""
 DAEMONIZE="yes"
-UNIXSOCKET="/tmp/redis.sock"
+HOSTNAME=$(hostname -s)
+UNIXSOCKET="/tmp/redis${HOSTNAME}.sock"
 UNIXSOCKETPERM="700"
 
 # Define the path to the Redis configuration file


### PR DESCRIPTION
unix socket start , changed from generic name. if used in a container, it will use the container name 