### PR TITLE
provide fallback string_view and define defaults at RedisConnection

### DIFF
--- a/RedisConnection.hpp
+++ b/RedisConnection.hpp
@@ -32,10 +32,10 @@ public:
   {
     std::string path;
     std::string host = "127.0.0.1";
-    std::string user;
+    std::string user = "default";
     std::string password;
     uint32_t timeout = 500;   //  milliseconds
-    uint16_t port = 0;
+    uint16_t port = 6379;
     uint16_t size = 5;
   };
 
@@ -86,9 +86,9 @@ public:
     else
     {
       co.host = opts.host;
-      if (opts.port) co.port = opts.port;   //  dont overwrite redis++ default with 0
+      co.port = opts.port;
     }
-    if (opts.user.size()) co.user = opts.user;  //  dont overwrite redis++ default with ""
+    co.user = opts.user;
     co.password = opts.password;
     co.socket_timeout = chr::milliseconds(opts.timeout);
 

--- a/spanCpp14.hpp
+++ b/spanCpp14.hpp
@@ -9,7 +9,7 @@
 #endif
 
 //  if the above did not define __cpp_lib_span
-//  provide our own implmentation of std::span
+//  provide our own implementation of std::span
 #ifndef __cpp_lib_span
 //  a very simple std::span
 namespace std
@@ -27,5 +27,23 @@ namespace std
     T* const _buf;
     const size_t _sz;
   };
+}
+#endif
+
+//  if there is a string_view header to include
+#if __has_include(<string_view>)
+//  include that string_view header
+#include <string_view>
+//  the string_view header should define __cpp_lib_string_view
+//  if it provides an implementation of std::string_view
+#endif
+
+//  if the above did not define __cpp_lib_string_view
+//  provide our own implementation of std::string_view
+#ifndef __cpp_lib_string_view
+//  alias string_view to string
+namespace std
+{
+  using string_view = string;
 }
 #endif


### PR DESCRIPTION
- alias std::string_view to std::string if std::string_view does not exist
- define all options defaults at RedisConnection instead of some there and some in redis++