### PR TITLE
put version in watchdog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,15 @@ list(APPEND REDIS_ADAPTER_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/redis-plus-plus/src
 list(APPEND REDIS_ADAPTER_LIBRARIES hiredis)
 list(APPEND REDIS_ADAPTER_LIBRARIES redis++_static)
 
+# Try to get the git commit hash
+set(REDIS_ADAPTER_GIT_COMMIT unknown)
+execute_process(COMMAND git rev-parse HEAD WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  OUTPUT_VARIABLE REDIS_ADAPTER_GIT_COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "redis-adapter git commit: ${REDIS_ADAPTER_GIT_COMMIT}")
+
+# Add git commit hash to compiler definitions globally
+add_compile_definitions(REDIS_ADAPTER_GIT_COMMIT="${REDIS_ADAPTER_GIT_COMMIT}")
+
 # Send the lists to the project that wants to include them
 get_directory_property(HAS_PARENT PARENT_DIRECTORY)
 if(HAS_PARENT)
@@ -57,6 +66,7 @@ set_target_properties(redis++_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # Build redis-adapter-test and googletest if REDIS_ADAPTER_TEST is true
 # Specify on command-line: "cmake -D REDIS_ADAPTER_TEST=1 .."
 if(REDIS_ADAPTER_TEST)
+  message(STATUS "REDIS_ADAPTER_TEST")
   # We dont want googlemock built
   option(BUILD_GMOCK "Builds the googlemock subproject" OFF)
   enable_testing()
@@ -70,6 +80,7 @@ endif()
 # Build redis-adapter-benchmark and googlebenchmark if REDIS_ADAPTER_BENCHMARK is true
 # Specify on command-line: "cmake -D REDIS_ADAPTER_BENCHMARK=1 .."
 if(REDIS_ADAPTER_BENCHMARK)
+  message(STATUS "REDIS_ADAPTER_BENCHMARK")
   # Disable Google Test dependency for benchmark
   set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Disable benchmark tests based on Google Test")
   set(BENCHMARK_USE_BUNDLED_GTEST OFF CACHE BOOL "Disable bundled Google Test in benchmark")

--- a/RedisAdapter.hpp
+++ b/RedisAdapter.hpp
@@ -11,6 +11,19 @@
 #include <atomic>
 
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//  define RA_VERSION
+//
+//  The version of this RedisAdapter (the stringified git commit hash)
+//  Get git commit hash during build and pass to compile using -D as REDIS_ADAPTER_GIT_COMMIT
+//
+#ifndef REDIS_ADAPTER_GIT_COMMIT
+#define REDIS_ADAPTER_GIT_COMMIT unknown
+#endif
+#define STRINGIFY(s) #s
+#define STRINGIFY_DEFINE(s) STRINGIFY(s)
+#define RA_VERSION STRINGIFY_DEFINE(REDIS_ADAPTER_GIT_COMMIT)
+
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //  struct RA_Time
 //
 //  Nanosecond time since epoch, provided as a result timestamp
@@ -225,7 +238,7 @@ public:
   //    return     : true if successful, false if not successful
   //
   bool addWatchdog(const std::string& dogname, uint32_t expiration)
-    { return _redis.hset(_watchdog_key, dogname, dogname) && petWatchdog(dogname, expiration); }
+    { return _redis.hset(_watchdog_key, dogname, RA_VERSION) && petWatchdog(dogname, expiration); }
 
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //  petWatchdog : refresh the expiration of a watchdog


### PR DESCRIPTION
harvest git commit hash during cmake
pass git commit hash to compiler during make
use git commit hash as redis-adapter version in watchdog hash
