### PR TITLE
squelch log err about HEXPIRE

### DIFF
--- a/RedisConnection.hpp
+++ b/RedisConnection.hpp
@@ -507,7 +507,16 @@ public:
       if (_cluster) _cluster->command("hexpire", key, std::to_string(sec), "fields", "1", fld, std::back_inserter(ret));
       if (_singler) _singler->command("hexpire", key, std::to_string(sec), "fields", "1", fld, std::back_inserter(ret));
     }
-    catch (const swr::Error& e) { syslog(LOG_ERR, "RedisConnection::%s %s", __func__, e.what()); }
+    catch (const swr::Error& e)
+    {
+      static bool squelch = false;
+      if ( ! squelch)
+      {
+        syslog(LOG_ERR, "RedisConnection::%s %s - %s", __func__, "HEXPIRE requires redis-server 7.4.0 or higher",
+                        "Upgrade redis-server to permit redis-adapter watchdog feature to function");
+        squelch = true;
+      }
+    }
     return ret.size() ? ret.front() : -1;
   }
 


### PR DESCRIPTION
Using the watchdog feature while connected to a redis-server that is not at least version 7.4.0 fills the syslog with errors about HEXPIRE failing.

Report only the first failure and recommend upgrading to 7.4.0 or higher.