### PR TITLE
Use HTTPS for public submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "googletest"]
 	path = googletest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "hiredis"]
 	path = hiredis
-	url = git@github.com:redis/hiredis.git
+	url = https://github.com/redis/hiredis.git
 [submodule "redis-plus-plus"]
 	path = redis-plus-plus
-	url = git@github.com:sewenew/redis-plus-plus.git
+	url = https://github.com/sewenew/redis-plus-plus.git
 [submodule "benchmark"]
 	path = benchmark
-	url = git@github.com:google/benchmark.git
+	url = https://github.com/google/benchmark.git


### PR DESCRIPTION
## Summary

Replace the four nested GitHub SSH submodule URLs with public HTTPS URLs.

This lets public downstream repositories use `git clone --recurse-submodules` without a GitHub account, SSH key, or credential helper. The submodule gitlinks are unchanged.

## Validation

- all four URLs resolve to the same public GitHub repositories
- no `git@github.com` URL remains in `.gitmodules`
- `redis-pvxs-ioc` will pin this commit and repeat a recursive clone with Git configuration, credential helpers, prompting, and SSH disabled
