### PR TITLE
Add exact Redis Stream trimming support

### DIFF
--- a/RedisAdapter.cpp
+++ b/RedisAdapter.cpp
@@ -120,7 +120,8 @@ RA_Time RedisAdapter::addSingleDouble(const string& subKey, double data, const R
   string key = build_key(subKey);
   Attrs attrs = default_field_attrs(data);
 
-  string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), attrs.begin(), attrs.end(), args.trim)
+  string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), attrs.begin(), attrs.end(),
+                                         args.trim, args.approximateTrim)
                         : _redis.xadd(key, args.time.id_or_now(), attrs.begin(), attrs.end());
 
   if (reconnect(id.size()) == 0) { return RA_NOT_CONNECTED; }

--- a/RedisAdapter.hpp
+++ b/RedisAdapter.hpp
@@ -79,7 +79,14 @@ struct RA_ArgsGet
 { std::string baseKey; RA_Time minTime; RA_Time maxTime; uint32_t count = 1; };
 
 struct RA_ArgsAdd
-{ RA_Time time; uint32_t trim = 1; };
+{
+  RA_Time time;
+  uint32_t trim = 1;
+  // Redis MAXLEN trimming is approximate by default for compatibility and
+  // throughput. Set false when a hard memory/entry bound is part of the data
+  // contract.
+  bool approximateTrim = true;
+};
 
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //  struct RA_Options
@@ -223,12 +230,14 @@ public:
   //  overload for array and span
   template<template<typename T, size_t S> class C, typename T, size_t S> RA_Time
   addSingleList(const std::string& subKey, const C<T, S>& data, const RA_ArgsAdd& args = {})
-    { return add_single_stream_list_helper(subKey, args.time, data.data(), data.size(), args.trim); }
+    { return add_single_stream_list_helper(subKey, args.time, data.data(), data.size(), args.trim,
+                                           args.approximateTrim); }
 
   //  overload for vector
   template<typename T> RA_Time
   addSingleList(const std::string& subKey, const std::vector<T>& data, const RA_ArgsAdd& args = {})
-    { return add_single_stream_list_helper(subKey, args.time, data.data(), data.size(), args.trim); }
+    { return add_single_stream_list_helper(subKey, args.time, data.data(), data.size(), args.trim,
+                                           args.approximateTrim); }
 
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //  connected : test if server is connected and responsive
@@ -459,7 +468,8 @@ private:
   get_single_stream_list_helper(const std::string& baseKey, const std::string& subKey, std::vector<T>& dest, RA_Time maxTime);
 
   template<typename T> RA_Time
-  add_single_stream_list_helper(const std::string& subKey, RA_Time time, const T* data, size_t size, uint32_t trim);
+  add_single_stream_list_helper(const std::string& subKey, RA_Time time, const T* data, size_t size,
+                                uint32_t trim, bool approximateTrim);
 
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //  Redis server

--- a/RedisAdapterTempl.hpp
+++ b/RedisAdapterTempl.hpp
@@ -426,7 +426,8 @@ RedisAdapter::addSingleValue(const std::string& subKey, const T& data, const RA_
   std::string key = build_key(subKey);
   Attrs attrs = default_field_attrs(data);
 
-  std::string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), attrs.begin(), attrs.end(), args.trim)
+  std::string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), attrs.begin(), attrs.end(),
+                                              args.trim, args.approximateTrim)
                              : _redis.xadd(key, args.time.id_or_now(), attrs.begin(), attrs.end());
 
   if ( ! reconnect(id.size())) { return RA_NOT_CONNECTED; }
@@ -439,7 +440,8 @@ RedisAdapter::addSingleValue(const std::string& subKey, const Attrs& data, const
 {
   std::string key = build_key(subKey);
 
-  std::string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), data.begin(), data.end(), args.trim)
+  std::string id = args.trim ? _redis.xaddTrim(key, args.time.id_or_now(), data.begin(), data.end(),
+                                              args.trim, args.approximateTrim)
                              : _redis.xadd(key, args.time.id_or_now(), data.begin(), data.end());
 
   if ( ! reconnect(id.size())) { return RA_NOT_CONNECTED; }
@@ -458,14 +460,16 @@ RedisAdapter::addSingleValue(const std::string& subKey, const Attrs& data, const
 //    return : time of the added data item if successful, zero on failure
 //
 template<typename T> RA_Time
-RedisAdapter::add_single_stream_list_helper(const std::string& subKey, RA_Time time, const T* data, size_t size, uint32_t trim)
+RedisAdapter::add_single_stream_list_helper(const std::string& subKey, RA_Time time, const T* data,
+                                            size_t size, uint32_t trim, bool approximateTrim)
 {
   static_assert(std::is_trivial<T>(), "wrong type T");
 
   std::string key = build_key(subKey);
   Attrs attrs = default_field_attrs(data, size);
 
-  std::string id = trim ? _redis.xaddTrim(key, time.id_or_now(), attrs.begin(), attrs.end(), trim)
+  std::string id = trim ? _redis.xaddTrim(key, time.id_or_now(), attrs.begin(), attrs.end(), trim,
+                                         approximateTrim)
                         : _redis.xadd(key, time.id_or_now(), attrs.begin(), attrs.end());
 
   if ( ! reconnect(id.size())) { return RA_NOT_CONNECTED; }

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,8 @@ their own freshness expectations.
 
 `RA_ArgsAdd.time` selects an explicit timestamp; zero asks the adapter to use
 host time. `RA_ArgsAdd.trim` defaults to 1, making a stream a latest-value store.
+`RA_ArgsAdd.approximateTrim` defaults to `true`; set it to `false` when the
+stream contract requires a strict maximum entry count.
 Use a larger trim target when the application contract requires history.
 
 The generic typed path stores its binary-safe payload under the `_` stream

--- a/mock/MockRedisAdapter.hpp
+++ b/mock/MockRedisAdapter.hpp
@@ -32,7 +32,7 @@ struct RA_Time
 };
 
 struct RA_ArgsAdd
-  { RA_Time time; uint32_t trim = 1; };
+  { RA_Time time; uint32_t trim = 1; bool approximateTrim = true; };
 
 class MockRedisAdapter // Mock
 {

--- a/test.cpp
+++ b/test.cpp
@@ -85,6 +85,24 @@ TEST(RedisAdapter, DataSingle)
   EXPECT_EQ(vi[2], 3);
 }
 
+TEST(RedisAdapter, ExactTrim)
+{
+  RedisAdapter redis("TEST");
+  ASSERT_TRUE(redis.del("exact-trim"));
+
+  for (int value = 0; value < 10; ++value)
+  {
+    EXPECT_TRUE(redis.addSingleValue("exact-trim", value,
+      { .trim = 3, .approximateTrim = false }).ok());
+  }
+
+  const auto values = redis.getValues<int>("exact-trim");
+  ASSERT_EQ(values.size(), 3);
+  EXPECT_EQ(values[0].second, 7);
+  EXPECT_EQ(values[1].second, 8);
+  EXPECT_EQ(values[2].second, 9);
+}
+
 TEST(RedisAdapter, Data)
 {
   RedisAdapter redis("TEST");


### PR DESCRIPTION
## Summary

- add an `RA_ArgsAdd::approximateTrim` option for Redis Stream writes
- preserve the existing approximate `MAXLEN ~` behavior by default
- allow callers with a hard memory or entry-count contract to request exact
  `MAXLEN =` trimming
- cover exact retention in the Redis-backed test suite and document the new
  argument

## Motivation

Image streams can contain multi-megabyte entries, so Redis's approximate trim
may materially exceed a configured memory budget. The AreaDetector Redis data
plane uses this option to retain exactly 16 recent frames while keeping the
existing behavior unchanged for all current callers.

## Verification

- the new test writes ten values with a retention of three and verifies the
  exact final entries
- ADRedis builds against this branch in the full ADAravis IOC image
- the deployed GE1350 stream remained exactly 16 entries during a 600-frame
  real-camera comparison and concurrent PVA/video fanout
